### PR TITLE
Add ability to specify filters to search by

### DIFF
--- a/lib/money-heuristics/analyzer.rb
+++ b/lib/money-heuristics/analyzer.rb
@@ -7,20 +7,16 @@ module MoneyHeuristics
       @str = (str || '').dup
       @search_tree = search_tree
       @currencies = []
-      @methods = { iso_code: "search_by_iso_code", 
-                   symbol: "search_by_symbol", 
-                   name: "search_by_name" }
+      @methods = { iso_code: :search_by_iso_code, 
+                   symbol: :search_by_symbol, 
+                   name: :search_by_name }
     end
 
     def process(filters)
       format
       return [] if str.empty?
 
-      if (methods.keys & filters).any?
-        filters.each{ |filter| send(methods[filter]) }
-      else
-        methods.values.each{|method| send(method)}
-      end
+      filter_methods(filters).each { |method| send(method) }
 
       prepare_reply
     end
@@ -84,6 +80,14 @@ module MoneyHeuristics
       codes.uniq!
       codes.sort!
       codes
+    end
+
+    def filter_methods(filters)
+      filtered = methods.values_at(*filters).compact
+
+      return methods.values if filtered.empty?
+
+      filtered
     end
   end
 end

--- a/lib/money-heuristics/analyzer.rb
+++ b/lib/money-heuristics/analyzer.rb
@@ -1,21 +1,26 @@
 module MoneyHeuristics
   class Analyzer
     attr_reader :search_tree, :words
-    attr_accessor :str, :currencies
+    attr_accessor :str, :currencies, :methods
 
     def initialize(str, search_tree)
       @str = (str || '').dup
       @search_tree = search_tree
       @currencies = []
+      @methods = { iso_code: "search_by_iso_code", 
+                   symbol: "search_by_symbol", 
+                   name: "search_by_name" }
     end
 
-    def process
+    def process(filters)
       format
       return [] if str.empty?
 
-      search_by_symbol
-      search_by_iso_code
-      search_by_name
+      if (methods.keys & filters).any?
+        filters.each{ |filter| send(methods[filter]) }
+      else
+        methods.values.each{|method| send(method)}
+      end
 
       prepare_reply
     end

--- a/lib/money-heuristics/heuristics.rb
+++ b/lib/money-heuristics/heuristics.rb
@@ -10,10 +10,10 @@ module MoneyHeuristics
     # currency in an entire sentence
     #
     # Returns: Array (matched results)
-    def analyze(str)
+    def analyze(str, *filters)
       @_heuristics_search_tree ||= MoneyHeuristics::SearchTree.new(table).build
 
-      return MoneyHeuristics::Analyzer.new(str, @_heuristics_search_tree).process
+      return MoneyHeuristics::Analyzer.new(str, @_heuristics_search_tree).process(filters)
     end
   end
 end

--- a/lib/money-heuristics/heuristics.rb
+++ b/lib/money-heuristics/heuristics.rb
@@ -10,7 +10,7 @@ module MoneyHeuristics
     # currency in an entire sentence
     #
     # Returns: Array (matched results)
-    def analyze(str, *filters)
+    def analyze(str, filters: [])
       @_heuristics_search_tree ||= MoneyHeuristics::SearchTree.new(table).build
 
       return MoneyHeuristics::Analyzer.new(str, @_heuristics_search_tree).process(filters)

--- a/spec/heuristics_spec.rb
+++ b/spec/heuristics_spec.rb
@@ -161,12 +161,12 @@ describe MoneyHeuristics do
 
     context "with filters" do
         it "finds only by specified filters" do
-          expect(it.analyze("10 ₮ + 2USD", :iso_code)).to eq ["USD"]
-          expect(it.analyze("10 ₮ + 2USD", :iso_code, :symbol)).to eq ["MNT", "USD"]
+          expect(it.analyze("10 ₮ + 2USD", filters: [:iso_code])).to eq ["USD"]
+          expect(it.analyze("10 ₮ + 2USD", filters: [:iso_code, :symbol])).to eq ["MNT", "USD"]
         end
 
         it "ignores nonexistent filters" do
-          expect(it.analyze("10 ₮ + 2USD", :wrong_method)).to eq ["MNT", "USD"]
+          expect(it.analyze("10 ₮ + 2USD", filters: [:wrong_filter])).to eq ["MNT", "USD"]
         end
     end
   end

--- a/spec/heuristics_spec.rb
+++ b/spec/heuristics_spec.rb
@@ -158,5 +158,16 @@ describe MoneyHeuristics do
     it "should function with unicode characters" do
       expect(it.analyze("10 դր.")).to eq ["AMD"]
     end
+
+    context "with filters" do
+        it "finds only by specified filters" do
+          expect(it.analyze("10 ₮ + 2USD", :iso_code)).to eq ["USD"]
+          expect(it.analyze("10 ₮ + 2USD", :iso_code, :symbol)).to eq ["MNT", "USD"]
+        end
+
+        it "ignores nonexistent filters" do
+          expect(it.analyze("10 ₮ + 2USD", :wrong_method)).to eq ["MNT", "USD"]
+        end
+    end
   end
 end


### PR DESCRIPTION
As discussed in this [issue](https://github.com/RubyMoney/money-heuristics/issues/2), this PR adds the ability to pass in filters, so that `Analyzer` only can do only specific checks (only by name, only by iso code, etc)

Looking at your other tests, I've kept mine short as well, but do let me know if you want me to extend the test coverage. 

I've also gone for a more metaprogramming approach for calling search methods, which might not be as readable as before, but reduces duplication. Again, if that's an issue, I am happy to do a more straightforward implementation. 